### PR TITLE
Adds ML fundamental matrix estimation (Bundle Adjustment)

### DIFF
--- a/demo/example_fundamental_matrix.jl
+++ b/demo/example_fundamental_matrix.jl
@@ -15,7 +15,7 @@ close(file)
 img1g = Gray.(img1)
 img2g = Gray.(img2)
 
-plotlyjs()
+#plotlyjs()
 
 _, npts1 = size(inlier_pts1)
 _, npts2 = size(inlier_pts2)

--- a/src/MultipleViewGeometry.jl
+++ b/src/MultipleViewGeometry.jl
@@ -11,6 +11,7 @@ export HomogeneousPoint, ProjectiveEntity, FundamentalMatrix, ProjectionMatrix
 export EssentialMatrix
 export CameraModel, Pinhole, CanonicalLens
 export EstimationAlgorithm, DirectLinearTransform, Taubin, FundamentalNumericalScheme
+export BundleAdjustment
 export CostFunction, ApproximateMaximumLikelihood, AML
 export HomogeneousCoordinates
 export CoordinateSystemTransformation, CanonicalToHartley, HartleyToCanonical
@@ -23,7 +24,7 @@ export NoiseModel, GaussianNoise
 export ⊗, ∑, √
 
 # Functions exported from `operators.jl`.
-export 𝑛, ∂𝑛, smallest_eigenpair,vec2antisym
+export 𝑛, ∂𝑛, smallest_eigenpair,vec2antisym, hom⁻¹, hom, ∂hom⁻¹
 
 # Functions exported from `hartley_transformation.jl`.
 export hartley_normalization, hartley_normalization!, hartley_transformation

--- a/src/draw/ModuleDraw.jl
+++ b/src/draw/ModuleDraw.jl
@@ -1,7 +1,7 @@
 module ModuleDraw
 using MultipleViewGeometry.ModuleTypes, MultipleViewGeometry.ModuleOperators, MultipleViewGeometry.ModuleMathAliases
 using StaticArrays
-using Plots, Plotly
+using Plots #, Plotly
 using Juno
 
 export draw!, EpipolarLineGraphic, LineSegment3D, PlaneSegment3D, Camera3D

--- a/src/estimate/ModuleEstimation.jl
+++ b/src/estimate/ModuleEstimation.jl
@@ -1,9 +1,10 @@
 module ModuleEstimation
 using MultipleViewGeometry.ModuleTypes, MultipleViewGeometry.ModuleDataNormalization, MultipleViewGeometry.ModuleOperators, MultipleViewGeometry.ModuleMathAliases
 using MultipleViewGeometry.ModuleMoments, MultipleViewGeometry.ModuleCarriers, MultipleViewGeometry.ModuleCostFunction
-using MultipleViewGeometry.ModuleTransform
+using MultipleViewGeometry.ModuleTransform, MultipleViewGeometry
 using StaticArrays
 using Juno
+using LsqFit
 export estimate
 include("estimate_twoview.jl")
 end

--- a/src/operators/ModuleOperators.jl
+++ b/src/operators/ModuleOperators.jl
@@ -2,5 +2,6 @@ module ModuleOperators
 using StaticArrays
 using MultipleViewGeometry.ModuleMathAliases, MultipleViewGeometry.ModuleTypes
 export 𝑛, ∂𝑛, smallest_eigenpair,vec2antisym
+export hom, hom⁻¹, ∂hom⁻¹
 include("operators.jl")
 end

--- a/src/operators/operators.jl
+++ b/src/operators/operators.jl
@@ -36,6 +36,28 @@ function 𝑛(v::AbstractArray)
     end
 end
 
+function 𝑛(v::SVector)
+    if v[end] != 0 && v[end] != 1
+        v / v[end]
+    else
+        v
+    end
+end
+
+function hom⁻¹(v::SVector)
+    pop(v / v[end])
+end
+
+function hom(v::SVector)
+    push(v,1)
+end
+
+function ∂hom⁻¹(𝐧::SVector)
+    k = length(𝐧)
+    𝐞ₖ = push(zeros(SVector{k-1}),1.0)
+    𝐈 = @SMatrix eye(k)
+    1/𝐧[k]*𝐈 - 1/𝐧[k]^2 * 𝐧 * 𝐞ₖ'
+end
 
 function ∂𝑛(𝐧::AbstractArray)
     k = length(𝐧)

--- a/src/types/ModuleTypes.jl
+++ b/src/types/ModuleTypes.jl
@@ -5,6 +5,7 @@ export HomogeneousPoint, ProjectiveEntity, FundamentalMatrix, ProjectionMatrix
 export HomogeneousCoordinates, EssentialMatrix
 export CameraModel, Pinhole, CanonicalLens
 export EstimationAlgorithm, DirectLinearTransform, Taubin, FundamentalNumericalScheme
+export BundleAdjustment
 export CostFunction, ApproximateMaximumLikelihood, AML
 export CoordinateSystemTransformation, CanonicalToHartley, HartleyToCanonical
 export CovarianceMatrices

--- a/src/types/types.jl
+++ b/src/types/types.jl
@@ -71,6 +71,12 @@ end
 type DirectLinearTransform <: EstimationAlgorithm
 end
 
+type BundleAdjustment <: EstimationAlgorithm
+    𝛉₀::Matrix{Float64}
+    max_iter::Int8
+    toleranceθ::Float64
+end
+
 type FundamentalNumericalScheme <: EstimationAlgorithm
     𝛉₀::Matrix{Float64}
     max_iter::Int8

--- a/test/estimate_twoview_tests.jl
+++ b/test/estimate_twoview_tests.jl
@@ -1,11 +1,12 @@
 using MultipleViewGeometry, Base.Test
-using StaticArrays
+using MultipleViewGeometry.ModuleTypes
+using StaticArrays, Calculus
 # Tests for fundamental matrix estimation
 
 
 𝒳 = [Point3DH(x,y,z,1.0)
                         for x=-100:5:100 for y=-100:5:100 for z=1:-50:-100]
-
+𝒳 = 𝒳[1:50:end]
 # Intrinsic and extrinsic parameters of camera one.
 𝐊₁ = eye(3)
 𝐑₁ = eye(3)
@@ -43,7 +44,7 @@ for correspondence in zip(1:length(ℳ),ℳ, ℳʹ)
     i, m , mʹ = correspondence
     𝐦  = 𝑛(m)
     𝐦ʹ = 𝑛(mʹ)
-    residual[i] = (𝐦ʹ'*𝐅*𝐦) 
+    residual[i] = (𝐦ʹ'*𝐅*𝐦)
 end
 
 @test isapprox(sum(residual), 0.0; atol = 1e-7)
@@ -79,3 +80,11 @@ end
 # 𝐅ₜ = 𝐅ₜ / sign(𝐅ₜ[1,2])
 #
 # @test 𝐅 ≈ 𝐅ₜ
+
+# Test the Bundle Adjustment estimator on the Fundamental matrix problem.
+𝐅, lsqFit = estimate(FundamentalMatrix(),
+                        BundleAdjustment(reshape(𝐅₀,9,1), 5, 1e-10),
+                                                           (ℳ, ℳʹ))
+𝐅 = 𝐅 / norm(𝐅)
+𝐅 = 𝐅 / sign(𝐅[1,2])
+@test 𝐅 ≈ 𝐅ₜ


### PR DESCRIPTION
Implemented bundle adjustment for gold-standard fundamental matrix estimation (i.e. reprojection error). Incorporated analytic Jacobian. At the moment the memory for the Jacobian gets allocated at each iteration. This is something that ought to be addressed in the future.